### PR TITLE
4.3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -546,7 +546,8 @@ textarea::placeholder, .textbox::placeholder, pre::placeholder, #title-notes::pl
     /* box-shadow: 0px 0px 0px 1px var(--on-textbox-color); */
     z-index: 100;
     max-height: 300px;
-    overflow: visible;
+    overflow-x: hidden;
+    overflow-y: auto;
     /* box-sizing: content-box; */
     /* border: 0px; */
 }

--- a/js/background.js
+++ b/js/background.js
@@ -755,13 +755,22 @@ function getPageUrl(url, with_protocol = true) {
     }
 
     //https://page.example/search#section1
-    if (settings_json["consider-sections"] === "no") {
+    if (settings_json["consider-sections"] === "no" || settings_json["consider-parameters"] === false) {
         if (url.includes("#")) urlToReturn = urlToReturn.split("#")[0];
     }
 
     //https://page.example/search?parameters
-    if (settings_json["consider-parameters"] === "no") {
-        if (url.includes("?")) urlToReturn = urlToReturn.split("?")[0];
+    if (settings_json["consider-parameters"] === "no" || settings_json["consider-parameters"] === false) {
+        if (url.includes("?")) {
+            urlToReturn = urlToReturn.split("?")[0];
+            if (urlToReturn.includes("#")) {
+                //if it includes sections, then check if consider-sections is "no"
+                //if it's "no", then remove the section
+                if (settings_json["consider-sections"] === "no" || settings_json["consider-sections"] === false) {
+                    urlToReturn = urlToReturn.replace(urlToReturn.split("#")[0], "");
+                }
+            }
+        }
     }
 
     //console.log(urlToReturn);
@@ -1212,7 +1221,18 @@ function getAllOtherPossibleUrls(url) {
     let urlsToReturn = [];
 
     if (urlToReturn.includes("/")) {
-        let urlPartsTemp = urlToReturn.split("/");
+        //remove before the "?" and "#" if it exists
+
+        let urlPartsTemp = [];
+
+        urlPartsTemp = urlToReturn.split("/");
+        if (urlToReturn.includes("?")) {
+            urlPartsTemp = urlToReturn.split("?")[0].split("/");
+        }
+        if (urlToReturn.includes("#")) {
+            urlPartsTemp = urlToReturn.split("#")[0].split("/");
+        }
+
         let urlConcat = "/";
         for (let urlFor = 3; urlFor < urlPartsTemp.length; urlFor++) {
             if (urlPartsTemp[urlFor] !== "") {
@@ -1225,7 +1245,59 @@ function getAllOtherPossibleUrls(url) {
         }
     }
 
+    //get also the all possible combinations of parameters
+    //example: https://example.com/search?param1=1&param2=2&param3=3
+    //it should add urls like: https://example.com/search?param1=*, https://example.com/search?param2=*, https://example.com/search?param3=*, https://example.com/search?param1=*&param2=*, https://example.com/search?param1=*&param3=*, https://example.com/search?param2=*&param3=*, https://example.com/search?param1=*&param2=*&param3=*
+
+    if (settings_json["consider-parameters"] === "no" || settings_json["consider-parameters"] === false) {
+        let urlToReturnTemp = urlToReturn;
+        if (urlToReturn.includes("?")) {
+            let urlPartsTemp = urlToReturn.split("?");
+            urlToReturnTemp = urlPartsTemp[0];
+            let parameters = urlPartsTemp[1].split("&");
+            let parametersToReturn = [];
+            for (let i = 0; i < parameters.length; i++) {
+                let parameterParts = parameters[i].split("=");
+                if (parameterParts[1] !== "") {
+                    parametersToReturn.push(parameterParts[0] + "=*");
+                }
+            }
+            for (let i = 1; i <= parametersToReturn.length; i++) {
+                let combinations = getCombinations(parametersToReturn, i);
+                for (let j = 0; j < combinations.length; j++) {
+                    let urlToPush = urlToReturnTemp + "?" + combinations[j].join("&");
+                    if (urlToPush !== getDomainUrl(url)) {
+                        urlsToReturn.push(urlToPush);
+                    }
+                }
+            }
+        }
+    }
+
     return urlsToReturn;
+}
+
+
+/**
+ * Generates all combinations of the elements in the array, taken n at a time.
+ * @param {Array} array - The array of elements.
+ * @param {number} n - The number of elements in each combination.
+ * @returns {Array} - An array of combinations, each combination is an array.
+ */
+function getCombinations(array, n) {
+    let result = [];
+    let f = function (prefix, array) {
+        for (let i = 0; i < array.length; i++) {
+            let newPrefix = prefix.concat(array[i]);
+            if (newPrefix.length === n) {
+                result.push(newPrefix);
+            } else {
+                f(newPrefix, array.slice(i + 1));
+            }
+        }
+    };
+    f([], array);
+    return result;
 }
 
 function setOpenedSticky(sticky, minimized) {

--- a/js/background.js
+++ b/js/background.js
@@ -1247,27 +1247,33 @@ function getAllOtherPossibleUrls(url) {
 
     //get also the all possible combinations of parameters
     //example: https://example.com/search?param1=1&param2=2&param3=3
-    //it should add urls like: https://example.com/search?param1=*, https://example.com/search?param2=*, https://example.com/search?param3=*, https://example.com/search?param1=*&param2=*, https://example.com/search?param1=*&param3=*, https://example.com/search?param2=*&param3=*, https://example.com/search?param1=*&param2=*&param3=*
+    //it should add urls like: https://example.com/search?param1=1, https://example.com/search?param2=2, https://example.com/search?param3=3, https://example.com/search?param1=1&param2=2, https://example.com/search?param1=1&param3=3, https://example.com/search?param2=2&param3=3, https://example.com/search?param1=1&param2=2&param3=3
 
-    if (settings_json["consider-parameters"] === "no" || settings_json["consider-parameters"] === false) {
-        let urlToReturnTemp = urlToReturn;
-        if (urlToReturn.includes("?")) {
-            let urlPartsTemp = urlToReturn.split("?");
-            urlToReturnTemp = urlPartsTemp[0];
-            let parameters = urlPartsTemp[1].split("&");
-            let parametersToReturn = [];
-            for (let i = 0; i < parameters.length; i++) {
-                let parameterParts = parameters[i].split("=");
-                if (parameterParts[1] !== "") {
-                    parametersToReturn.push(parameterParts[0] + "=*");
-                }
+    if (urlToReturn.includes("/")) {
+        if (settings_json["consider-parameters"] === "no" || settings_json["consider-parameters"] === false) {
+            let urlToReturnTemp = "/" + urlToReturn.split("/")[urlToReturn.split("/").length - 1];
+            if (urlToReturn.includes("#")) {
+                urlToReturnTemp = urlToReturn.split("#")[0].split("/");
             }
-            for (let i = 1; i <= parametersToReturn.length; i++) {
-                let combinations = getCombinations(parametersToReturn, i);
-                for (let j = 0; j < combinations.length; j++) {
-                    let urlToPush = urlToReturnTemp + "?" + combinations[j].join("&");
-                    if (urlToPush !== getDomainUrl(url)) {
-                        urlsToReturn.push(urlToPush);
+
+            if (urlToReturn.includes("?")) {
+                let urlPartsTemp = urlToReturnTemp.split("?");
+                urlToReturnTemp = urlPartsTemp[0];
+                let parameters = urlPartsTemp[1].split("&");
+                let parametersToReturn = [];
+                for (let i = 0; i < parameters.length; i++) {
+                    let parameterParts = parameters[i].split("=");
+                    if (parameterParts[1] !== "") {
+                        parametersToReturn.push(parameterParts[0] + "=" + parameterParts[1]);
+                    }
+                }
+                for (let i = 1; i <= parametersToReturn.length; i++) {
+                    let combinations = getCombinations(parametersToReturn, i);
+                    for (let j = 0; j < combinations.length; j++) {
+                        let urlToPush = urlToReturnTemp + "?" + combinations[j].join("&");
+                        if (urlToPush !== getDomainUrl(url)) {
+                            urlsToReturn.push(urlToPush);
+                        }
                     }
                 }
             }

--- a/js/inject/sticky-notes.js
+++ b/js/inject/sticky-notes.js
@@ -111,13 +111,27 @@ function updateStickyNotes() {
                 if (new_tag === "none") new_tag = "transparent";
                 tag.style.backgroundColor = new_tag;
 
+                let displayWidth = window.innerWidth;
+                let displayHeight = window.innerHeight;
+                let x = checkCorrectNumber(response.notes.sticky_params.coords.x, "20px");
+                let y = checkCorrectNumber(response.notes.sticky_params.coords.y, "20px");
+                let h = checkCorrectNumber(response.notes.sticky_params.sizes.h, "300px");
+                let w = checkCorrectNumber(response.notes.sticky_params.sizes.w, "300px");
+                let yAsInt = parseInt(y.replace("px", ""));
+                let hAsInt = parseInt(h.replace("px", ""));
+                let xAsInt = parseInt(x.replace("px", ""));
+                let wAsInt = parseInt(w.replace("px", ""));
+
                 if (response.notes !== undefined && response.notes.sticky_params.coords !== undefined) {
-                    stickyNotes.style.left = checkCorrectNumber(response.notes.sticky_params.coords.x, "20px");
-                    stickyNotes.style.top = checkCorrectNumber(response.notes.sticky_params.coords.y, "20px");
+                    let safeTop = (((yAsInt + hAsInt) > displayHeight ? displayHeight - hAsInt : yAsInt)) + "px";
+                    let safeLeft = (((xAsInt + wAsInt) > displayWidth ? displayWidth - wAsInt : xAsInt)) + "px";
+
+                    stickyNotes.style.left = safeLeft;
+                    stickyNotes.style.top = safeTop;
                 }
                 if (response.notes !== undefined && response.notes.sticky_params.sizes !== undefined) {
-                    stickyNotes.style.width = checkCorrectNumber(response.notes.sticky_params.sizes.w, "300px");
-                    stickyNotes.style.height = checkCorrectNumber(response.notes.sticky_params.sizes.h, "300px");
+                    stickyNotes.style.width = w;
+                    stickyNotes.style.height = h;
                 }
                 if (response.notes !== undefined && response.notes.sticky_params.opacity !== undefined) {
                     //stickyNotes.style.opacity = response.notes.sticky_params.opacity.value;
@@ -449,14 +463,23 @@ function getCSS(notes, x = "10px", y = "10px", w = "200px", h = "300px", opacity
         if (theme_colours_json["on-primary"] !== undefined) on_primary_color = theme_colours_json["on-primary"];
         if (theme_colours_json["on-secondary"] !== undefined) on_secondary_color = theme_colours_json["on-secondary"];
     }
+    let displayWidth = window.innerWidth;
+    let displayHeight = window.innerHeight;
+    let yAsInt = parseInt(y.replace("px", ""));
+    let hAsInt = parseInt(h.replace("px", ""));
+    let xAsInt = parseInt(x.replace("px", ""));
+    let wAsInt = parseInt(w.replace("px", ""));
+
+    let safeTop = (((yAsInt + hAsInt) > displayHeight ? displayHeight - hAsInt : yAsInt)) + "px";
+    let safeLeft = (((xAsInt + wAsInt) > displayWidth ? displayWidth - wAsInt : xAsInt)) + "px";
 
     return `
             @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Lora:ital,wght@0,400..700;1,400..700&family=Merienda:wght@300..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Noto+Serif:ital,wght@0,100..900;1,100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Roboto:ital,wght@0,100..900;1,100..900&family=Shantell+Sans:ital,wght@0,300..800;1,300..800&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Victor+Mono:ital,wght@0,100..700;1,100..700&display=swap');
             
             #sticky-notes-notefox-addon {
                 position: fixed;
-                top: ${y};
-                left:  ${x};
+                top: ${safeTop};
+                left:  ${safeLeft};
                 width: ${w};
                 height:  ${h};
                 background-color: ${primary_color};
@@ -786,6 +809,62 @@ function getCSS(notes, x = "10px", y = "10px", w = "200px", h = "300px", opacity
             
             #text--sticky-notes-notefox-addon {
                 visibility: visible !important;
+            }
+            
+            @media screen and (max-width: ${wAsInt > 800 ? w : "800px"}) {
+                /*Mobile*/
+                #sticky-notes-notefox-addon {
+                    top: 0px !important;
+                    left: 0px !important;
+                    right: 0px !important;
+                    bottom: 0px !important;
+                    width: 100% !important;
+                    height: 100% !important;
+                }
+                
+                #text--sticky-notes-notefox-addon, #text-container--sticky-notes-notefox-addon {
+                    font-size: 1.2em !important;
+                }
+                
+                #commands-container--sticky-notes-notefox-addon {
+                    visibility: visible !important;
+                }
+                
+                #move--sticky-notes-notefox-addon, #page-or-domain--sticky-notes-notefox-addon {
+                    height: auto !important;
+                    font-size: 1em !important;
+                    padding: 10px !important;
+                }
+                
+                #close--sticky-notes-notefox-addon, #minimize--sticky-notes-notefox-addon {
+                    width: 50px !important;
+                    height: 50px !important;
+                    margin: 2px !important;
+                }
+                
+                #text-container--sticky-notes-notefox-addon {
+                    top: 50px !important;
+                    bottom: 50px !important;
+                }
+                
+                #slider-container--sticky-notes-notefox-addon {
+                    left: 15px !important;
+                    right: 15px !important;
+                    bottom: 10px !important;
+                }
+                
+                #resize--sticky-notes-notefox-addon {
+                    display: none !important;
+                }
+                
+                #slider--sticky-notes-notefox-addon {
+                    height: 10px !important;
+                }
+                
+                #slider--sticky-notes-notefox-addon::-moz-range-thumb {
+                    width: 25px;
+                    height: 25px;
+                }
             }
             `;
 }
@@ -1230,8 +1309,23 @@ function getCSSMinimized(settings_json, icons_json, theme_colours_json) {
             }
             #restore--sticky-notes-notefox-addon:hover {
                 opacity: 1;
-                height: 80px;
+                /*height: 80px;*/
                 width: 30px;
                 box-shadow: 0px 0px 5px #fff;
-            }`;
+            }
+            @media screen and (max-width: 800px) {
+                /*Mobile*/
+                #restore--sticky-notes-notefox-addon {
+                    top: 10%;
+                    height: 150px;
+                    width: 40px !important;
+                    opacity: 0.7 !important;
+                }
+                
+                #restore--sticky-notes-notefox-addon:hover {
+                    opacity: 1;
+                    width: 50px;
+                }
+            }
+            `;
 }

--- a/js/script.js
+++ b/js/script.js
@@ -1013,6 +1013,7 @@ function getAllOtherPossibleUrls(url) {
             if (urlPartsTemp[urlFor] !== "") {
                 urlConcat += urlPartsTemp[urlFor];
                 if (urlConcat !== getDomainUrl(url)) {
+                    console.log(urlConcat);
                     urlsToReturn.push(urlConcat + "/*");
                 }
                 urlConcat += "/";
@@ -1022,27 +1023,33 @@ function getAllOtherPossibleUrls(url) {
 
     //get also the all possible combinations of parameters
     //example: https://example.com/search?param1=1&param2=2&param3=3
-    //it should add urls like: https://example.com/search?param1=*, https://example.com/search?param2=*, https://example.com/search?param3=*, https://example.com/search?param1=*&param2=*, https://example.com/search?param1=*&param3=*, https://example.com/search?param2=*&param3=*, https://example.com/search?param1=*&param2=*&param3=*
+    //it should add urls like: https://example.com/search?param1=1, https://example.com/search?param2=2, https://example.com/search?param3=3, https://example.com/search?param1=1&param2=2, https://example.com/search?param1=1&param3=3, https://example.com/search?param2=2&param3=3, https://example.com/search?param1=1&param2=2&param3=3
 
-    if (settings_json["consider-parameters"] === "no" || settings_json["consider-parameters"] === false) {
-        let urlToReturnTemp = urlToReturn;
-        if (urlToReturn.includes("?")) {
-            let urlPartsTemp = urlToReturn.split("?");
-            urlToReturnTemp = urlPartsTemp[0];
-            let parameters = urlPartsTemp[1].split("&");
-            let parametersToReturn = [];
-            for (let i = 0; i < parameters.length; i++) {
-                let parameterParts = parameters[i].split("=");
-                if (parameterParts[1] !== "") {
-                    parametersToReturn.push(parameterParts[0] + "=*");
-                }
+    if (urlToReturn.includes("/")) {
+        if (settings_json["consider-parameters"] === "no" || settings_json["consider-parameters"] === false) {
+            let urlToReturnTemp = "/" + urlToReturn.split("/")[urlToReturn.split("/").length - 1];
+            if (urlToReturn.includes("#")) {
+                urlToReturnTemp = urlToReturn.split("#")[0].split("/");
             }
-            for (let i = 1; i <= parametersToReturn.length; i++) {
-                let combinations = getCombinations(parametersToReturn, i);
-                for (let j = 0; j < combinations.length; j++) {
-                    let urlToPush = urlToReturnTemp + "?" + combinations[j].join("&");
-                    if (urlToPush !== getDomainUrl(url)) {
-                        urlsToReturn.push(urlToPush);
+
+            if (urlToReturn.includes("?")) {
+                let urlPartsTemp = urlToReturnTemp.split("?");
+                urlToReturnTemp = urlPartsTemp[0];
+                let parameters = urlPartsTemp[1].split("&");
+                let parametersToReturn = [];
+                for (let i = 0; i < parameters.length; i++) {
+                    let parameterParts = parameters[i].split("=");
+                    if (parameterParts[1] !== "") {
+                        parametersToReturn.push(parameterParts[0] + "=" + parameterParts[1]);
+                    }
+                }
+                for (let i = 1; i <= parametersToReturn.length; i++) {
+                    let combinations = getCombinations(parametersToReturn, i);
+                    for (let j = 0; j < combinations.length; j++) {
+                        let urlToPush = urlToReturnTemp + "?" + combinations[j].join("&");
+                        if (urlToPush !== getDomainUrl(url)) {
+                            urlsToReturn.push(urlToPush);
+                        }
                     }
                 }
             }
@@ -1117,8 +1124,8 @@ function setTab(index, url) {
 
     document.getElementsByClassName("tab")[index].classList.add("tab-sel");
 
-    //console.log("url", url)
-    //console.log("getPage(url)", getPageUrl(url));
+    console.log("url", url)
+    console.log("getPage(url)", getPageUrl(url));
 
     let never_saved = true;
     let notes = "";

--- a/js/script.js
+++ b/js/script.js
@@ -247,18 +247,19 @@ function loadUI() {
                         }
                         //console.log(url + " : " + tmp_check);
                     });
+
                     if (opened_by === 1 || (opened_by === -1 && check_for_domain && (default_index === 1 || default_index === 2 && !check_for_page || default_index === 0 && !check_for_global))) {
                         //by domain
                         setTab(1, currentUrl[1]);
                     } else if (opened_by === 2 || (opened_by === -1 && check_for_page && (default_index === 2 || default_index === 1 && !check_for_domain || default_index === 0 && !check_for_global))) {
                         //by page
                         setTab(2, currentUrl[2]);
-                    } else if (opened_by === 0 || (opened_by === -1 && check_for_global && (default_index === 0 || default_index === 1 && !check_for_domain || default_index === 2 && !check_for_page))) {
-                        //by global
-                        setTab(0, currentUrl[0]);
                     } else if (opened_by === -1 && check_for_subdomains) {
                         //by subdomain
                         setTab(3, currentUrl[3]);
+                    } else if (opened_by === 0 || (opened_by === -1 && check_for_global && (default_index === 0 || default_index === 1 && !check_for_domain || default_index === 2 && !check_for_page))) {
+                        //by global
+                        setTab(0, currentUrl[0]);
                     } else {
                         //using default
                         if (opened_by !== -1) {
@@ -955,13 +956,22 @@ function getPageUrl(url, with_protocol = true) {
     }
 
     //https://page.example/search#section1
-    if (settings_json["consider-sections"] === "no") {
+    if (settings_json["consider-sections"] === "no" || settings_json["consider-parameters"] === "no") {
         if (url.includes("#")) urlToReturn = urlToReturn.split("#")[0];
     }
 
     //https://page.example/search?parameters
-    if (settings_json["consider-parameters"] === "no") {
-        if (url.includes("?")) urlToReturn = urlToReturn.split("?")[0];
+    if (settings_json["consider-parameters"] === "no" || settings_json["consider-parameters"] === false) {
+        if (url.includes("?")) {
+            urlToReturn = urlToReturn.split("?")[0];
+            if (urlToReturn.includes("#")) {
+                //if it includes sections, then check if consider-sections is "no"
+                //if it's "no", then remove the section
+                if (settings_json["consider-sections"] === "no" || settings_json["consider-sections"] === false) {
+                    urlToReturn = urlToReturn.replace(urlToReturn.split("#")[0], "");
+                }
+            }
+        }
     }
 
     //console.log(urlToReturn);
@@ -986,7 +996,18 @@ function getAllOtherPossibleUrls(url) {
     let urlsToReturn = [];
 
     if (urlToReturn.includes("/")) {
-        let urlPartsTemp = urlToReturn.split("/");
+        //remove before the "?" and "#" if it exists
+
+        let urlPartsTemp = [];
+
+        urlPartsTemp = urlToReturn.split("/");
+        if (urlToReturn.includes("?")) {
+            urlPartsTemp = urlToReturn.split("?")[0].split("/");
+        }
+        if (urlToReturn.includes("#")) {
+            urlPartsTemp = urlToReturn.split("#")[0].split("/");
+        }
+
         let urlConcat = "/";
         for (let urlFor = 3; urlFor < urlPartsTemp.length; urlFor++) {
             if (urlPartsTemp[urlFor] !== "") {
@@ -999,7 +1020,58 @@ function getAllOtherPossibleUrls(url) {
         }
     }
 
+    //get also the all possible combinations of parameters
+    //example: https://example.com/search?param1=1&param2=2&param3=3
+    //it should add urls like: https://example.com/search?param1=*, https://example.com/search?param2=*, https://example.com/search?param3=*, https://example.com/search?param1=*&param2=*, https://example.com/search?param1=*&param3=*, https://example.com/search?param2=*&param3=*, https://example.com/search?param1=*&param2=*&param3=*
+
+    if (settings_json["consider-parameters"] === "no" || settings_json["consider-parameters"] === false) {
+        let urlToReturnTemp = urlToReturn;
+        if (urlToReturn.includes("?")) {
+            let urlPartsTemp = urlToReturn.split("?");
+            urlToReturnTemp = urlPartsTemp[0];
+            let parameters = urlPartsTemp[1].split("&");
+            let parametersToReturn = [];
+            for (let i = 0; i < parameters.length; i++) {
+                let parameterParts = parameters[i].split("=");
+                if (parameterParts[1] !== "") {
+                    parametersToReturn.push(parameterParts[0] + "=*");
+                }
+            }
+            for (let i = 1; i <= parametersToReturn.length; i++) {
+                let combinations = getCombinations(parametersToReturn, i);
+                for (let j = 0; j < combinations.length; j++) {
+                    let urlToPush = urlToReturnTemp + "?" + combinations[j].join("&");
+                    if (urlToPush !== getDomainUrl(url)) {
+                        urlsToReturn.push(urlToPush);
+                    }
+                }
+            }
+        }
+    }
+
     return urlsToReturn;
+}
+
+/**
+ * Generates all combinations of the elements in the array, taken n at a time.
+ * @param {Array} array - The array of elements.
+ * @param {number} n - The number of elements in each combination.
+ * @returns {Array} - An array of combinations, each combination is an array.
+ */
+function getCombinations(array, n) {
+    let result = [];
+    let f = function (prefix, array) {
+        for (let i = 0; i < array.length; i++) {
+            let newPrefix = prefix.concat(array[i]);
+            if (newPrefix.length === n) {
+                result.push(newPrefix);
+            } else {
+                f(newPrefix, array.slice(i + 1));
+            }
+        }
+    };
+    f([], array);
+    return result;
 }
 
 function getTheProtocol(url) {
@@ -1045,13 +1117,16 @@ function setTab(index, url) {
 
     document.getElementsByClassName("tab")[index].classList.add("tab-sel");
 
+    //console.log("url", url)
+    //console.log("getPage(url)", getPageUrl(url));
+
     let never_saved = true;
     let notes = "";
     let title = "";
-    if (checkAllSupportedProtocols(getPageUrl(url), websites_json) && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["notes"] !== undefined) {
+    if (checkAllSupportedProtocols(url, websites_json) && websites_json[getUrlWithSupportedProtocol(url, websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(url, websites_json)]["notes"] !== undefined) {
         //notes saved (also it's empty)
-        notes = websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["notes"];
-        title = websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["title"];
+        notes = websites_json[getUrlWithSupportedProtocol(url, websites_json)]["notes"];
+        title = websites_json[getUrlWithSupportedProtocol(url, websites_json)]["title"];
         listenerLinks();
         never_saved = false;
     }
@@ -1077,19 +1152,19 @@ function setTab(index, url) {
     }
 
     let last_update = all_strings["never-update"];
-    if (checkAllSupportedProtocols(getPageUrl(url), websites_json) && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["last-update"] !== undefined) last_update = websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["last-update"];
+    if (checkAllSupportedProtocols(url, websites_json) && websites_json[getUrlWithSupportedProtocol(url, websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(url, websites_json)]["last-update"] !== undefined) last_update = websites_json[getUrlWithSupportedProtocol(url, websites_json)]["last-update"];
     document.getElementById("last-updated-section").textContent = all_strings["last-update-text"].replaceAll("{{date_time}}", datetimeToDisplay(last_update));
 
     let colour = "none";
     document.getElementById("tag-colour-section").removeAttribute("class");
-    if (checkAllSupportedProtocols(getPageUrl(url), websites_json) && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["tag-colour"] !== undefined) colour = websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["tag-colour"];
+    if (checkAllSupportedProtocols(url, websites_json) && websites_json[getUrlWithSupportedProtocol(url, websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(url, websites_json)]["tag-colour"] !== undefined) colour = websites_json[getUrlWithSupportedProtocol(url, websites_json)]["tag-colour"];
     document.getElementById("tag-colour-section").classList.add("tag-colour-top", "tag-colour-" + colour);
     if (websites_json[currentUrl[selected_tab]] !== undefined) document.getElementById("tag-select-grid").value = websites_json[currentUrl[selected_tab]]["tag-colour"];
 
     let sticky = false;
-    if (checkAllSupportedProtocols(getPageUrl(url), websites_json) && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["sticky"] !== undefined) sticky = websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["sticky"];
+    if (checkAllSupportedProtocols(url, websites_json) && websites_json[getUrlWithSupportedProtocol(url, websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(url, websites_json)]["sticky"] !== undefined) sticky = websites_json[getUrlWithSupportedProtocol(url, websites_json)]["sticky"];
     let minimized = false;
-    if (checkAllSupportedProtocols(getPageUrl(url), websites_json) && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["minimized"] !== undefined) minimized = websites_json[getUrlWithSupportedProtocol(getPageUrl(url), websites_json)]["minimized"];
+    if (checkAllSupportedProtocols(url, websites_json) && websites_json[getUrlWithSupportedProtocol(url, websites_json)] !== undefined && websites_json[getUrlWithSupportedProtocol(url, websites_json)]["minimized"] !== undefined) minimized = websites_json[getUrlWithSupportedProtocol(url, websites_json)]["minimized"];
 
     document.getElementById("notes").focus();
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Notefox: Websites notes",
   "author": "Saverio Morelli (Sav22999)",
-  "version": "4.2.1",
+  "version": "4.3",
   "description": "Take notes on every website in a smart and simple way!",
   "icons": {
     "16": "./img/icon.svg",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Notefox: Websites notes",
   "author": "Saverio Morelli (Sav22999)",
-  "version": "4.2.0.1",
+  "version": "4.2.1",
   "description": "Take notes on every website in a smart and simple way!",
   "icons": {
     "16": "./img/icon.svg",

--- a/settings/index.html
+++ b/settings/index.html
@@ -703,7 +703,7 @@ Created by Saverio Morelli - saveriomorelli.com
                         <span class="item-radio-font-family-preview-item primary"
                               id="preview-font-family-playfairdisplay">Notefox</span>
                     </span>
-                    <span class="item-radio-title item-radio-title-font-family" id="font-family-select-playfairdisplay">Notefox</span>
+                    <span class="item-radio-title item-radio-title-font-family" id="font-family-select-playfairdisplay">Playfair Display</span>
                 </label>
 
                 <label class="item-radio-font-family" id="item-radio-font-family-roboto">


### PR DESCRIPTION
- Extended the "•••" urls (now you can choose also from all the parameters, also if the [consider-parameters] is enabled).

> Example: `https://example.com/search?param1=1&param2=2&param3=3`, then you'll be to choose from all the combinations, so: `https://example.com/search?param1=1`, `https://example.com/search?param2=2`, `https://example.com/search?param3=3`, `https://example.com/search?param1=1&param2=2`, `https://example.com/search?param1=1&param3=3, https://example.com/search?param2=2&param3=3`, `https://example.com/search?param1=1&param2=2&param3=3`

- Improved the check for sections
- Fixed a bug with "subdomains" priority (before: Page > Domain > Global > Subdomains, now: Page > Domain > Subdomains > Global)